### PR TITLE
feat: opt-in Pointer Events for Tocada (desktop + unified input)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,8 @@ export function classifyTapGesture(
 
 The main `Tocada` class in `index.ts` should only:
 
-- Set up and tear down event listeners
-- Maintain state between touch events
+- Set up and tear down event listeners (Pointer Events by default, or Touch Events when `pointerEvents: false`)
+- Maintain state between input events (pointer or touch pipeline)
 - Call detector functions to classify gestures
 - Dispatch custom events
 
@@ -180,7 +180,7 @@ Update `src/index.ts`:
 
 1. Import the detector function
 2. Add any necessary state variables
-3. Call the detector in the appropriate touch handler
+3. Call the detector from the appropriate pointer or touch handler in `index.ts`
 4. Dispatch the event with details
 
 ### Step 5: Update Documentation
@@ -223,7 +223,7 @@ describe("classifyRotation", () => {
 
 ```typescript
 // Good
-it("should return null when touch count is below minimum", () => { });
+it("should return null when contact count is below minimum", () => { });
 
 // Avoid
 it("works", () => { });

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tocada JS
 
-Touch Events with ease
+Pointer and touch gestures with ease
 
 ## Installation
 
@@ -11,10 +11,10 @@ npm install tocada
 ## Basic Usage
 
 ```javascript
-import { useTouchEvents } from "tocada";
+import { usePointerEvents } from "tocada";
 
-// Pass a query selector or HTMLElement
-const swipeArea = useTouchEvents("#my-element");
+// Pass a query selector or HTMLElement (Pointer Events by default: mouse, pen, touch)
+const swipeArea = usePointerEvents("#my-element");
 
 // Listen for events
 swipeArea.element.addEventListener("swipe", (e) => {
@@ -24,6 +24,8 @@ swipeArea.element.addEventListener("swipe", (e) => {
 // Clean up when done
 swipeArea.destroy();
 ```
+
+For **TouchEvent-only** input (legacy mobile pipelines), use `useTouchEvents` instead—it forces `pointerEvents: false`.
 
 ## Available Events
 
@@ -62,16 +64,16 @@ swipeArea.destroy();
 ## Configuration Options
 
 ```javascript
-import { useTouchEvents } from "tocada";
+import { usePointerEvents } from "tocada";
 
-const swipeArea = useTouchEvents("#my-element", {
+const swipeArea = usePointerEvents("#my-element", {
   // Prefix all event names (e.g., "myapp-swipe", "myapp-tap")
   eventPrefix: "myapp-",
-  
-  // Enable high-precision element tracking (fills gaps between touchmove events)
+
+  // Enable high-precision element tracking (fills gaps between move events)
   // Adds computational overhead - use when you need complete element coverage
   useHighPrecision: true,
-  
+
   // Customize detection thresholds
   thresholds: {
     swipeThreshold: 50,        // Min distance for swipe (px)
@@ -213,7 +215,7 @@ When `useHighPrecision: true` is enabled, Tocada provides additional element tra
 ### Usage
 
 ```javascript
-const swipeArea = useTouchEvents("#my-element", {
+const swipeArea = usePointerEvents("#my-element", {
   useHighPrecision: true
 });
 
@@ -263,7 +265,8 @@ These native APIs can be useful for:
 Tocada is written in TypeScript and exports all types:
 
 ```typescript
-import { 
+import {
+  usePointerEvents,
   useTouchEvents,
   ITocadaOptions,
   ISwipeEventDetails,

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For **TouchEvent-only** input (legacy mobile pipelines), use `useTouchEvents` in
 | `doubletap` | Two taps within 300ms |
 | `press` | Touch held 200-500ms |
 | `hold` | Touch held > 500ms |
-| `swipe` | Fires before directional swipe events |
+| `swipe` | Fires before directional swipe events (same gesture also emits `swipeup` / `swipedown` / etc.) |
 | `swipeup` | Swipe in upward direction |
 | `swipedown` | Swipe in downward direction |
 | `swipeleft` | Swipe in left direction |

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ swipeArea.destroy();
 
 For **TouchEvent-only** input (legacy mobile pipelines), use `useTouchEvents` instead—it forces `pointerEvents: false`.
 
+`new Tocada(selectorOrElement)` is the same as passing **`{ pointerEvents: true }`** (Pointer Events). Use **`{ pointerEvents: false }`** or **`useTouchEvents(...)`** only when you need the legacy touch stack.
+
 ## Available Events
 
-### Single Touch Events
+### Single-contact events
 
 | Event | Description |
 |-------|-------------|
@@ -45,11 +47,11 @@ For **TouchEvent-only** input (legacy mobile pipelines), use `useTouchEvents` in
 | `swipeclockwise` | Circular swipe in clockwise direction |
 | `swipecounterclockwise` | Circular swipe in counter-clockwise direction |
 
-### Multi-Touch Events
+### Multi-contact events
 
 | Event | Description |
 |-------|-------------|
-| `gesture` | Fires before any multi-touch gesture |
+| `gesture` | Fires before any multi-contact gesture (`touchCount` is active pointer / touch count) |
 | `pinch` | Two fingers moving closer together |
 | `spread` | Two fingers moving apart |
 | `rotate` | Two-finger rotation (fires before directional) |
@@ -200,13 +202,13 @@ Each event type provides a `detail` object with relevant data.
 
 ```javascript
 {
-  touchCount,        // Number of simultaneous touches
+  touchCount,        // Active contacts (pointers or touches, depending on pipeline)
 }
 ```
 
-## High Precision Touch Tracking
+## High precision tracking
 
-When `useHighPrecision: true` is enabled, Tocada provides additional element tracking arrays to fill gaps between discrete `touchmove` events during rapid swipes. This is useful for:
+When `useHighPrecision: true` is enabled, Tocada provides additional element tracking arrays to fill gaps between discrete move samples (`pointermove` or `touchmove`, depending on pipeline) during rapid swipes. This is useful for:
 
 - **Visual feedback**: Highlighting all elements in a swipe path
 - **Game interactions**: Detecting all tiles/elements touched during a gesture
@@ -232,16 +234,16 @@ When `useHighPrecision: true`, three additional arrays are provided:
 
 - **`touchedPathElements`**: Elements found by sampling coordinates from the `touchPath` array. This fills gaps by checking elements at points along the recorded touch path.
 
-- **`interpolatedTouchedElements`**: Elements found via interpolation between consecutive `touchmove` events. Samples points every 5-10px along the interpolation path to catch elements that might have been missed.
+- **`interpolatedTouchedElements`**: Elements found via interpolation between consecutive move events. Samples points every 5–10px along the interpolation path to catch elements that might have been missed.
 
 - **`derivedTouchedElements`**: **Recommended to use**. A combined array that merges `touchedElements`, `interpolatedTouchedElements`, and `touchedPathElements`, then orders them chronologically by their position in the touch path and deduplicates them.
 
 ### Performance Considerations
 
 High precision tracking adds computational overhead as it:
-- Samples multiple points along the touch path
+- Samples multiple points along the path
 - Calls `document.elementFromPoint()` for each sampled point
-- Performs interpolation calculations during touch moves
+- Performs interpolation calculations during move events
 
 Only enable this feature when you need complete element coverage. For most use cases, the standard `touchedElements` array is sufficient.
 
@@ -251,21 +253,22 @@ For custom tracking needs or edge cases, you can use native browser APIs:
 
 - **`document.elementFromPoint(x, y)`**: Get the topmost element at specific coordinates
 - **`document.elementsFromPoint(x, y)`**: Get all elements at coordinates (in stack order)
-- **`TouchEvent.touches`**: Access raw touch data during move events
-- **`TouchEvent.changedTouches`**: Touches that changed in the current event
+- **`PointerEvent`**: When using the default pointer pipeline, `pressure`, `pointerId`, and coalesced move events are available from the browser.
+- **`TouchEvent.touches`** (touch pipeline only): Access raw touch data during move events
+- **`TouchEvent.changedTouches`** (touch pipeline only): Touches that changed in the current event
 
 These native APIs can be useful for:
 - Custom interpolation logic
 - Handling edge cases not covered by Tocada
-- Building specialized touch tracking features
-- Debugging touch event behavior
+- Building specialized gesture tracking features
+- Debugging pointer or touch behavior
 
 ## TypeScript Support
 
 Tocada is written in TypeScript and exports all types:
 
 ```typescript
-import {
+import Tocada, {
   usePointerEvents,
   useTouchEvents,
   ITocadaOptions,

--- a/gh-pages/gh-pages.ts
+++ b/gh-pages/gh-pages.ts
@@ -154,15 +154,15 @@ for (let i = 0; i < gridSize * gridSize; i++) {
   touchArea.appendChild(square);
 }
 
-// Pointer events by default (mouse, pen, touch); see useTouchEvents() for touch-only.
-let touchHandler = new Tocada(touchArea, {
+// Default: Pointer Events (mouse, pen, touch). For TouchEvent-only, use useTouchEvents() from the bundle.
+let gestureHandler = new Tocada(touchArea, {
   useHighPrecision: (useHighPrecisionCheckbox as HTMLInputElement).checked,
 });
 
 useHighPrecisionCheckbox.addEventListener("change", (e) => {
   const useHighPrecision = (e.target as HTMLInputElement).checked;
-  touchHandler.destroy();
-  touchHandler = new Tocada(touchArea, { useHighPrecision });
+  gestureHandler.destroy();
+  gestureHandler = new Tocada(touchArea, { useHighPrecision });
 }); 
 
 // Track recent events (keep only 2 most recent)
@@ -172,9 +172,9 @@ const recentEvents: Array<{
   timestamp: Date;
 }> = [];
 
-// All available touch events
+// All gesture event names (custom events on touchArea)
 const eventNames = [
-  // Single touch events
+  // Single-contact
   "tap",
   "doubletap",
   "press",
@@ -186,7 +186,7 @@ const eventNames = [
   "swiperight",
   "swipeclockwise",
   "swipecounterclockwise",
-  // Multi-touch events
+  // Multi-contact
   "gesture",
   "pinch",
   "spread",
@@ -251,7 +251,7 @@ function formatEventDetails(eventType: string, detail: any): string {
     parts.push(`Scale: ${detail.scale.toFixed(2)}`);
   }
   if (detail.touchCount !== undefined) {
-    parts.push(`Touches: ${detail.touchCount}`);
+    parts.push(`Contacts: ${detail.touchCount}`);
   }
   if (detail.arc !== undefined) {
     parts.push(`Arc: ${Math.round(detail.arc)}°`);
@@ -266,7 +266,7 @@ function updateEventDisplay() {
   
   if (recentEvents.length === 0) {
     eventDisplay.innerHTML =
-      '<p class="text-muted">Touch the grid above to see events here...</p>';
+      '<p class="text-muted">Use the grid above to see gesture events here…</p>';
     return;
   }
 
@@ -286,7 +286,7 @@ function updateEventDisplay() {
   eventDisplay.innerHTML = html;
 }
 
-// Listen to all touch events
+// Listen for all gesture custom events
 eventNames.forEach((eventName) => {
   touchArea.addEventListener(eventName, (e: Event) => {
     const customEvent = e as CustomEvent;

--- a/gh-pages/gh-pages.ts
+++ b/gh-pages/gh-pages.ts
@@ -1,4 +1,4 @@
-import { useTouchEvents } from "../dist/index.js";
+import Tocada from "../dist/index.js";
 
 const touchArea = document.getElementById("touchArea");
 const eventDisplay = document.getElementById("eventDisplay");
@@ -154,13 +154,15 @@ for (let i = 0; i < gridSize * gridSize; i++) {
   touchArea.appendChild(square);
 }
 
-// Initialize touch events
-let touchHandler = useTouchEvents(touchArea, { useHighPrecision: (useHighPrecisionCheckbox as HTMLInputElement).checked });
+// Pointer events by default (mouse, pen, touch); see useTouchEvents() for touch-only.
+let touchHandler = new Tocada(touchArea, {
+  useHighPrecision: (useHighPrecisionCheckbox as HTMLInputElement).checked,
+});
 
 useHighPrecisionCheckbox.addEventListener("change", (e) => {
   const useHighPrecision = (e.target as HTMLInputElement).checked;
   touchHandler.destroy();
-  touchHandler = useTouchEvents(touchArea, { useHighPrecision });
+  touchHandler = new Tocada(touchArea, { useHighPrecision });
 }); 
 
 // Track recent events (keep only 2 most recent)

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -9,7 +9,7 @@
       integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
       crossorigin="anonymous"
     />
-    <title>Tocada JS - Touch Events Demo</title>
+    <title>Tocada JS - Gesture demo</title>
     <style>
       .touch-grid {
         display: grid;
@@ -256,7 +256,7 @@
         <div class="d-flex justify-content-between align-items-center flex-wrap">
           <div>
             <h1 class="mb-1">Tocada JS</h1>
-            <p class="text-muted mb-0">Touch Events with ease</p>
+            <p class="text-muted mb-0">Pointer &amp; touch gestures with ease</p>
           </div>
           <div>
             <a
@@ -271,18 +271,18 @@
         <hr />
       </header>
 
-      <!-- Touch Grid Area -->
+      <!-- Gesture grid -->
       <div class="mb-4">
-        <h3 class="mb-3">Touch Area - Interact with the squares below</h3>
+        <h3 class="mb-3">Gesture area — interact with the squares below</h3>
         <label><input type="checkbox" id="useHighPrecision" checked> Use High Precision</label>
         <div id="touchArea" class="touch-grid"></div>
       </div>
 
       <!-- Event Display -->
       <div class="event-display">
-        <h4 class="mb-3">Recent Touch Events</h4>
+        <h4 class="mb-3">Recent gesture events</h4>
         <div id="eventDisplay">
-          <p class="text-muted">Touch the grid above to see events here...</p>
+          <p class="text-muted">Use mouse, pen, or touch on the grid above to see events here…</p>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
       rel="stylesheet"
       href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
     />
-    <title>My Bootstrap Page</title>
+    <title>Tocada — gesture demo</title>
   </head>
 
   <body>
@@ -15,7 +15,7 @@
       <div class="row">
         <div id="touchArea" class="col-8 border" style="height: 50vh; background-color: lightblue">
           <h1>Tocada</h1>
-          <p>Touch events with ease!</p>
+          <p>Pointer &amp; touch gestures with ease!</p>
           <strong>Inspired by the wonderful Tocca.js library</strong>
           <small>Written in Typescript with love</small>
           <h2>Swipe around</h2>
@@ -32,7 +32,7 @@
     <!-- <script type="module" src="/index.js"></script> -->
 
     <script type="module">
-      import Tocada from "./dist/index.js";
+      import Tocada, { usePointerEvents } from "./dist/index.js";
       console.log(Tocada);
 
       const touchArea = document.getElementById("touchArea");
@@ -45,7 +45,7 @@
       debugEl.appendChild(start);
 
       try {
-        const swipeHandler = new Tocada(touchArea);
+        const swipeHandler = usePointerEvents(touchArea);
         const eventNames = [
           "swipe",
           "swipeleft",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tocada",
-  "version": "2.3.0",
-  "description": "Touch events with ease! (Inspired by the wonderful Tocca.js library). Written in Typescript with love",
+  "version": "3.0.0",
+  "description": "Pointer and touch gestures with ease! (Inspired by the wonderful Tocca.js library). Written in Typescript with love",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -40,6 +40,8 @@
   "homepage": "https://github.com/tamb/tocada.js",
   "keywords": [
     "touch",
+    "pointer",
+    "pointer-events",
     "events",
     "mobile",
     "swipe",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import Tocada, { useTouchEvents, DEFAULT_THRESHOLDS } from "./index";
+import Tocada, { useTouchEvents, usePointerEvents, DEFAULT_THRESHOLDS } from "./index";
 
 describe("useTouchEvents", () => {
   it("should return Tocada instance", () => {
@@ -114,6 +114,91 @@ function createMockTouchEvent(
   
   return event as TouchEvent;
 }
+
+function createMockPointerEvent(
+  type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel",
+  pointerId: number,
+  clientX: number,
+  clientY: number,
+  opts?: { buttons?: number; pointerType?: string }
+): PointerEvent {
+  const ev = new Event(type, { bubbles: true, cancelable: true }) as unknown as PointerEvent;
+  Object.assign(ev as object, {
+    pointerId,
+    clientX,
+    clientY,
+    pageX: clientX,
+    pageY: clientY,
+    button: 0,
+    buttons: opts?.buttons ?? 1,
+    pointerType: opts?.pointerType ?? "touch",
+    pressure: 0.5,
+    preventDefault: () => {},
+  });
+  return ev;
+}
+
+describe("Pointer Events mode", () => {
+  it("usePointerEvents returns Tocada instance", () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const t = usePointerEvents(el);
+    expect(t).toBeInstanceOf(Tocada);
+    t.destroy();
+    document.body.removeChild(el);
+  });
+
+  it("fires generic gesture before rotate for two-pointer rotation", () => {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    const tocada = new Tocada(element, { pointerEvents: true });
+
+    const events: string[] = [];
+    element.addEventListener("gesture", () => events.push("gesture"));
+    element.addEventListener("rotate", () => events.push("rotate"));
+    element.addEventListener("rotateclockwise", () => events.push("rotateclockwise"));
+
+    element.dispatchEvent(createMockPointerEvent("pointerdown", 1, 100, 100));
+    element.dispatchEvent(createMockPointerEvent("pointerdown", 2, 200, 100));
+
+    element.dispatchEvent(createMockPointerEvent("pointermove", 1, 100, 150));
+    element.dispatchEvent(createMockPointerEvent("pointermove", 2, 200, 50));
+
+    element.dispatchEvent(createMockPointerEvent("pointerup", 1, 100, 150, { buttons: 1 }));
+    element.dispatchEvent(createMockPointerEvent("pointerup", 2, 200, 50, { buttons: 0 }));
+
+    expect(events[0]).toBe("gesture");
+    expect(events).toContain("rotate");
+
+    tocada.destroy();
+    document.body.removeChild(element);
+  });
+
+  it("fires pinch when rotation is minimal (pointer)", () => {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    const tocada = new Tocada(element, { pointerEvents: true });
+
+    const events: string[] = [];
+    element.addEventListener("rotate", () => events.push("rotate"));
+    element.addEventListener("pinch", () => events.push("pinch"));
+
+    element.dispatchEvent(createMockPointerEvent("pointerdown", 1, 100, 100));
+    element.dispatchEvent(createMockPointerEvent("pointerdown", 2, 200, 100));
+
+    element.dispatchEvent(createMockPointerEvent("pointermove", 1, 120, 100));
+    element.dispatchEvent(createMockPointerEvent("pointermove", 2, 180, 100));
+
+    element.dispatchEvent(createMockPointerEvent("pointerup", 1, 120, 100, { buttons: 1 }));
+    element.dispatchEvent(createMockPointerEvent("pointerup", 2, 180, 100, { buttons: 0 }));
+
+    expect(events).toContain("pinch");
+    expect(events).not.toContain("rotate");
+
+    tocada.destroy();
+    document.body.removeChild(element);
+  });
+});
 
 describe("Gesture Event Priority", () => {
   let element: HTMLElement;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -151,7 +151,7 @@ describe("Pointer Events mode", () => {
   it("fires generic gesture before rotate for two-pointer rotation", () => {
     const element = document.createElement("div");
     document.body.appendChild(element);
-    const tocada = new Tocada(element, { pointerEvents: true });
+    const tocada = new Tocada(element);
 
     const events: string[] = [];
     element.addEventListener("gesture", () => events.push("gesture"));
@@ -177,7 +177,7 @@ describe("Pointer Events mode", () => {
   it("fires pinch when rotation is minimal (pointer)", () => {
     const element = document.createElement("div");
     document.body.appendChild(element);
-    const tocada = new Tocada(element, { pointerEvents: true });
+    const tocada = new Tocada(element);
 
     const events: string[] = [];
     element.addEventListener("rotate", () => events.push("rotate"));
@@ -207,7 +207,7 @@ describe("Gesture Event Priority", () => {
   beforeEach(() => {
     element = document.createElement("div");
     document.body.appendChild(element);
-    tocada = new Tocada(element);
+    tocada = new Tocada(element, { pointerEvents: false });
   });
 
   afterEach(() => {
@@ -341,6 +341,7 @@ describe("Gesture Event Priority", () => {
 
     // Create Tocada with higher rotation threshold
     const customTocada = new Tocada(element, {
+      pointerEvents: false,
       thresholds: {
         rotateMinAngle: 45, // Higher threshold
       },
@@ -381,6 +382,7 @@ describe("Gesture Event Priority", () => {
 
     // Create Tocada with higher pinch/spread threshold
     const customTocada = new Tocada(element, {
+      pointerEvents: false,
       thresholds: {
         pinchSpreadMinDistance: 50, // Higher threshold
       },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,20 +2,85 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import Tocada, { useTouchEvents, usePointerEvents, DEFAULT_THRESHOLDS } from "./index";
 
 describe("useTouchEvents", () => {
-  it("should return Tocada instance", () => {
+  it("returns Tocada instance wired to TouchEvent pipeline only", () => {
     expect(useTouchEvents("body")).toBeInstanceOf(Tocada);
+  });
+});
+
+describe("usePointerEvents", () => {
+  it("returns Tocada instance", () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const t = usePointerEvents(el);
+    expect(t).toBeInstanceOf(Tocada);
+    t.destroy();
+    document.body.removeChild(el);
+  });
+});
+
+describe("Input pipeline selection", () => {
+  function spyListenerTypes(el: HTMLElement) {
+    const types: string[] = [];
+    const orig = el.addEventListener.bind(el);
+    el.addEventListener = (
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions
+    ) => {
+      types.push(type);
+      return orig(type, listener, options as never);
+    };
+    return {
+      types,
+      restore: () => {
+        el.addEventListener = orig;
+      },
+    };
+  }
+
+  it("registers pointer listeners when pointerEvents is omitted (default)", () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const { types, restore } = spyListenerTypes(el);
+    const t = new Tocada(el);
+    restore();
+    expect(types).toEqual(["pointerdown", "pointermove", "pointerup", "pointercancel"]);
+    t.destroy();
+    document.body.removeChild(el);
+  });
+
+  it("useTouchEvents registers touch listeners only", () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const { types, restore } = spyListenerTypes(el);
+    const t = useTouchEvents(el);
+    restore();
+    expect(types).toEqual(["touchstart", "touchmove", "touchend"]);
+    t.destroy();
+    document.body.removeChild(el);
+  });
+
+  it("pointerEvents: false matches useTouchEvents listener set", () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const { types, restore } = spyListenerTypes(el);
+    const t = new Tocada(el, { pointerEvents: false });
+    restore();
+    expect(types).toEqual(["touchstart", "touchmove", "touchend"]);
+    t.destroy();
+    document.body.removeChild(el);
   });
 });
 
 describe("Tocada", () => {
   it("accepts query string as first argument", () => {
-    const touchEvents = new Tocada("body");
-    expect(touchEvents.element).toBeInstanceOf(HTMLElement);
+    const instance = new Tocada("body");
+    expect(instance.element).toBeInstanceOf(HTMLElement);
   });
 
   it("accepts HTMLElement as first argument", () => {
-    const touchEvents = new Tocada(document.querySelector("body") as HTMLElement);
-    expect(touchEvents.element).toBeInstanceOf(HTMLElement);
+    const instance = new Tocada(document.querySelector("body") as HTMLElement);
+    expect(instance.element).toBeInstanceOf(HTMLElement);
   });
 
   it("accepts custom thresholds", () => {
@@ -138,16 +203,7 @@ function createMockPointerEvent(
   return ev;
 }
 
-describe("Pointer Events mode", () => {
-  it("usePointerEvents returns Tocada instance", () => {
-    const el = document.createElement("div");
-    document.body.appendChild(el);
-    const t = usePointerEvents(el);
-    expect(t).toBeInstanceOf(Tocada);
-    t.destroy();
-    document.body.removeChild(el);
-  });
-
+describe("Pointer pipeline (default Tocada)", () => {
   it("fires generic gesture before rotate for two-pointer rotation", () => {
     const element = document.createElement("div");
     document.body.appendChild(element);
@@ -200,7 +256,7 @@ describe("Pointer Events mode", () => {
   });
 });
 
-describe("Gesture Event Priority", () => {
+describe("Gesture Event Priority (TouchEvent pipeline)", () => {
   let element: HTMLElement;
   let tocada: Tocada;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export default class Tocada {
   private eventPrefix: string = "";
   private useHighPrecision: boolean = false;
   private usePointerEvents: boolean = false;
-  /** Active pointers when {@link usePointerEvents} is true (key = pointerId). */
+  /** Active pointers when using the Pointer Events pipeline (key = pointerId). */
   private pointerById = new Map<number, { x: number; y: number; pressure: number }>();
 
   constructor(queryStringOrElement: string | HTMLElement, options: ITocadaOptions = {}) {
@@ -109,7 +109,7 @@ export default class Tocada {
       thresholds = {},
       eventPrefix = "",
       useHighPrecision = false,
-      pointerEvents = false,
+      pointerEvents = true,
     } = options;
     this.thresholds = {
       ...DEFAULT_THRESHOLDS,
@@ -904,14 +904,15 @@ export default class Tocada {
   }
 }
 
+/** Touch-only pipeline (`touchstart` / `touchmove` / `touchend`). Overrides default pointer mode. */
 export function useTouchEvents(
   queryStringOrElement: string | HTMLElement,
   options: ITocadaOptions = {}
 ) {
-  return new Tocada(queryStringOrElement, options);
+  return new Tocada(queryStringOrElement, { ...options, pointerEvents: false });
 }
 
-/** Same as {@link useTouchEvents} with `{ pointerEvents: true }` for Pointer Event input. */
+/** Explicit Pointer Events pipeline (default for {@link Tocada} and {@link usePointerEvents}). */
 export function usePointerEvents(
   queryStringOrElement: string | HTMLElement,
   options: Omit<ITocadaOptions, "pointerEvents"> = {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,9 @@ function coalescedPointerSlices(e: PointerEvent): PointerEvent[] {
   return [e];
 }
 
+/** Same object must be used for add + remove (passive/capture must match or listeners leak). */
+const POINTER_LISTENER_OPTIONS: AddEventListenerOptions = { passive: false };
+
 export default class Tocada {
   element: HTMLElement | null;
 
@@ -120,11 +123,10 @@ export default class Tocada {
     this.usePointerEvents = pointerEvents;
 
     if (this.usePointerEvents) {
-      const passiveOpts: AddEventListenerOptions = { passive: false };
-      this.element.addEventListener("pointerdown", this.handlePointerDown, passiveOpts);
-      this.element.addEventListener("pointermove", this.handlePointerMove, passiveOpts);
-      this.element.addEventListener("pointerup", this.handlePointerUp, passiveOpts);
-      this.element.addEventListener("pointercancel", this.handlePointerCancel, passiveOpts);
+      this.element.addEventListener("pointerdown", this.handlePointerDown, POINTER_LISTENER_OPTIONS);
+      this.element.addEventListener("pointermove", this.handlePointerMove, POINTER_LISTENER_OPTIONS);
+      this.element.addEventListener("pointerup", this.handlePointerUp, POINTER_LISTENER_OPTIONS);
+      this.element.addEventListener("pointercancel", this.handlePointerCancel, POINTER_LISTENER_OPTIONS);
     } else {
       this.element.addEventListener("touchstart", this.handleTouchStart, false);
       this.element.addEventListener("touchmove", this.handleTouchMove, false);
@@ -138,10 +140,10 @@ export default class Tocada {
         this.releasePointerCaptureSafe(id);
       }
       this.pointerById.clear();
-      this.element.removeEventListener("pointerdown", this.handlePointerDown);
-      this.element.removeEventListener("pointermove", this.handlePointerMove);
-      this.element.removeEventListener("pointerup", this.handlePointerUp);
-      this.element.removeEventListener("pointercancel", this.handlePointerCancel);
+      this.element.removeEventListener("pointerdown", this.handlePointerDown, POINTER_LISTENER_OPTIONS);
+      this.element.removeEventListener("pointermove", this.handlePointerMove, POINTER_LISTENER_OPTIONS);
+      this.element.removeEventListener("pointerup", this.handlePointerUp, POINTER_LISTENER_OPTIONS);
+      this.element.removeEventListener("pointercancel", this.handlePointerCancel, POINTER_LISTENER_OPTIONS);
     } else {
       this.element?.removeEventListener("touchstart", this.handleTouchStart);
       this.element?.removeEventListener("touchmove", this.handleTouchMove);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
   ICoords,
   DEFAULT_THRESHOLDS,
 } from "./types";
-import { getDistanceBetweenTouchPoints } from "./utils";
+import { getDistanceBetweenCoords, getDistanceBetweenTouchPoints } from "./utils";
 import { classifyTapGesture, isDoubleTap, isTapMovementValid } from "./detectors/tap";
 import { detectCircularDirection, getCircularSwipeInfo } from "./detectors/circular-swipe";
 // import {
@@ -30,6 +30,21 @@ import {
   classifyPinchSpread,
   buildPinchSpreadEventDetails,
 } from "./detectors/pinch-spread";
+
+function readPointerPressure(e: PointerEvent): number {
+  if (typeof e.pressure === "number" && e.pressure > 0) return e.pressure;
+  if (e.pointerType === "mouse") return 0.5;
+  return 0;
+}
+
+function coalescedPointerSlices(e: PointerEvent): PointerEvent[] {
+  const getCoalesced = e.getCoalescedEvents;
+  if (typeof getCoalesced === "function") {
+    const list = getCoalesced.call(e) as PointerEvent[] | undefined;
+    if (list && list.length > 0) return list;
+  }
+  return [e];
+}
 
 export default class Tocada {
   element: HTMLElement | null;
@@ -76,6 +91,9 @@ export default class Tocada {
   private thresholds!: Required<typeof DEFAULT_THRESHOLDS>;
   private eventPrefix: string = "";
   private useHighPrecision: boolean = false;
+  private usePointerEvents: boolean = false;
+  /** Active pointers when {@link usePointerEvents} is true (key = pointerId). */
+  private pointerById = new Map<number, { x: number; y: number; pressure: number }>();
 
   constructor(queryStringOrElement: string | HTMLElement, options: ITocadaOptions = {}) {
     this.element =
@@ -87,23 +105,48 @@ export default class Tocada {
       return;
     }
 
-    const { thresholds = {}, eventPrefix = "", useHighPrecision = false } = options;
+    const {
+      thresholds = {},
+      eventPrefix = "",
+      useHighPrecision = false,
+      pointerEvents = false,
+    } = options;
     this.thresholds = {
       ...DEFAULT_THRESHOLDS,
       ...thresholds,
     };
     this.eventPrefix = eventPrefix;
     this.useHighPrecision = useHighPrecision;
+    this.usePointerEvents = pointerEvents;
 
-    this.element.addEventListener("touchstart", this.handleTouchStart, false);
-    this.element.addEventListener("touchmove", this.handleTouchMove, false);
-    this.element.addEventListener("touchend", this.handleTouchEnd, false);
+    if (this.usePointerEvents) {
+      const passiveOpts: AddEventListenerOptions = { passive: false };
+      this.element.addEventListener("pointerdown", this.handlePointerDown, passiveOpts);
+      this.element.addEventListener("pointermove", this.handlePointerMove, passiveOpts);
+      this.element.addEventListener("pointerup", this.handlePointerUp, passiveOpts);
+      this.element.addEventListener("pointercancel", this.handlePointerCancel, passiveOpts);
+    } else {
+      this.element.addEventListener("touchstart", this.handleTouchStart, false);
+      this.element.addEventListener("touchmove", this.handleTouchMove, false);
+      this.element.addEventListener("touchend", this.handleTouchEnd, false);
+    }
   }
 
   destroy = () => {
-    this.element?.removeEventListener("touchstart", this.handleTouchStart);
-    this.element?.removeEventListener("touchmove", this.handleTouchMove);
-    this.element?.removeEventListener("touchend", this.handleTouchEnd);
+    if (this.usePointerEvents && this.element) {
+      for (const id of [...this.pointerById.keys()]) {
+        this.releasePointerCaptureSafe(id);
+      }
+      this.pointerById.clear();
+      this.element.removeEventListener("pointerdown", this.handlePointerDown);
+      this.element.removeEventListener("pointermove", this.handlePointerMove);
+      this.element.removeEventListener("pointerup", this.handlePointerUp);
+      this.element.removeEventListener("pointercancel", this.handlePointerCancel);
+    } else {
+      this.element?.removeEventListener("touchstart", this.handleTouchStart);
+      this.element?.removeEventListener("touchmove", this.handleTouchMove);
+      this.element?.removeEventListener("touchend", this.handleTouchEnd);
+    }
     this.clearTimers();
   };
 
@@ -113,6 +156,80 @@ export default class Tocada {
       this.holdTimer = null;
     }
   };
+
+  private beginSingleContactSession(clientX: number, clientY: number, pressure: number) {
+    this.startX = clientX;
+    this.startY = clientY;
+    this.startTime = Date.now();
+    this.startPressure = pressure;
+    this.startingElement = document.elementsFromPoint(this.startX, this.startY)[0] as HTMLElement;
+    this.holdFired = false;
+
+    this.touchedElements.push(this.startingElement);
+    this.touchPath = [{ x: this.startX, y: this.startY, time: this.startTime }];
+
+    if (this.useHighPrecision) {
+      this.lastTouchPosition = { x: this.startX, y: this.startY };
+    }
+
+    this.holdTimer = setTimeout(() => {
+      this.holdFired = true;
+      this.dispatchTapEvent("hold", {
+        duration: this.thresholds.holdMinTime,
+        pressure,
+        element: this.startingElement,
+        coords: { x: this.startX, y: this.startY },
+        startTime: this.startTime,
+        endTime: Date.now(),
+      });
+    }, this.thresholds.holdMinTime);
+  }
+
+  /** Single-contact move sampling (linear path, interpolation, circular-swipe path). */
+  private sampleSingleContactAlongPath(clientX: number, clientY: number) {
+    const x = clientX;
+    const y = clientY;
+    const element = document.elementFromPoint(x, y) as HTMLElement;
+    if (element && this.element && this.element.contains(element) && element !== this.element) {
+      this.touchedElements.push(element);
+    }
+
+    if (this.useHighPrecision && !this.isMultiTouch && this.lastTouchPosition) {
+      const distance = Math.sqrt(
+        Math.pow(x - this.lastTouchPosition.x, 2) + Math.pow(y - this.lastTouchPosition.y, 2)
+      );
+      const sampleInterval = Math.max(5, Math.min(10, distance / 10));
+      const steps = Math.floor(distance / sampleInterval);
+
+      for (let i = 1; i <= steps; i++) {
+        const t = i / (steps + 1);
+        const sampleX = this.lastTouchPosition.x + (x - this.lastTouchPosition.x) * t;
+        const sampleY = this.lastTouchPosition.y + (y - this.lastTouchPosition.y) * t;
+        const sampleElement = document.elementFromPoint(sampleX, sampleY) as HTMLElement;
+
+        if (
+          sampleElement &&
+          this.element &&
+          this.element.contains(sampleElement) &&
+          sampleElement !== this.element
+        ) {
+          this.interpolatedTouchedElements.push(sampleElement);
+        }
+      }
+    }
+
+    if (this.useHighPrecision && !this.isMultiTouch) {
+      this.lastTouchPosition = { x, y };
+    }
+
+    if (!this.isMultiTouch) {
+      this.touchPath.push({
+        x,
+        y,
+        time: Date.now(),
+      });
+    }
+  }
 
   private handleTouchStart = (event: TouchEvent) => {
     // Use event.touches.length as the source of truth for current touch count
@@ -175,55 +292,12 @@ export default class Tocada {
   };
 
   private handleTouchMove = (event: TouchEvent) => {
-    // Prevent default behavior to prevent scrolling
     event.preventDefault();
+    if (event.touches.length === 0) return;
     const x = event.touches[0].clientX;
     const y = event.touches[0].clientY;
-    const element = document.elementFromPoint(x, y) as HTMLElement;
-    // Only add elements that are descendants of the touch area (not the touch area itself)
-    if (element && this.element && this.element.contains(element) && element !== this.element) {
-      this.touchedElements.push(element);
-    }
 
-    // High precision interpolation
-    if (this.useHighPrecision && !this.isMultiTouch && this.lastTouchPosition) {
-      const distance = Math.sqrt(
-        Math.pow(x - this.lastTouchPosition.x, 2) + Math.pow(y - this.lastTouchPosition.y, 2)
-      );
-      // Sample points every 5-10px along the interpolation path
-      const sampleInterval = Math.max(5, Math.min(10, distance / 10));
-      const steps = Math.floor(distance / sampleInterval);
-      
-      for (let i = 1; i <= steps; i++) {
-        const t = i / (steps + 1);
-        const sampleX = this.lastTouchPosition.x + (x - this.lastTouchPosition.x) * t;
-        const sampleY = this.lastTouchPosition.y + (y - this.lastTouchPosition.y) * t;
-        const sampleElement = document.elementFromPoint(sampleX, sampleY) as HTMLElement;
-        
-        if (
-          sampleElement &&
-          this.element &&
-          this.element.contains(sampleElement) &&
-          sampleElement !== this.element
-        ) {
-          this.interpolatedTouchedElements.push(sampleElement);
-        }
-      }
-    }
-
-    // Update last touch position for interpolation
-    if (this.useHighPrecision && !this.isMultiTouch) {
-      this.lastTouchPosition = { x, y };
-    }
-
-    // Track touch path for circular swipe detection (single touch)
-    if (!this.isMultiTouch) {
-      this.touchPath.push({
-        x,
-        y,
-        time: Date.now(),
-      });
-    }
+    this.sampleSingleContactAlongPath(x, y);
 
     if (this.isMultiTouch) {
       this.handleGestureMove(event);
@@ -248,52 +322,18 @@ export default class Tocada {
 
   private handleSwipeStart = (event: TouchEvent) => {
     const touch = event.touches[0];
-    this.startX = touch.clientX;
-    this.startY = touch.clientY;
-    this.startTime = Date.now();
-    this.startPressure = touch.force || 0;
-    this.startingElement = document.elementsFromPoint(this.startX, this.startY)[0] as HTMLElement;
-    this.holdFired = false;
-
-    this.touchedElements.push(this.startingElement);
-    this.touchPath = [{ x: this.startX, y: this.startY, time: this.startTime }];
-    
-    // Initialize last touch position for interpolation
-    if (this.useHighPrecision) {
-      this.lastTouchPosition = { x: this.startX, y: this.startY };
-    }
-
-    // Start hold timer
-    this.holdTimer = setTimeout(() => {
-      this.holdFired = true;
-      this.dispatchTapEvent("hold", {
-        duration: this.thresholds.holdMinTime,
-        pressure: touch.force || 0,
-        element: this.startingElement,
-        coords: { x: this.startX, y: this.startY },
-        startTime: this.startTime,
-        endTime: Date.now(),
-      });
-    }, this.thresholds.holdMinTime);
+    this.beginSingleContactSession(touch.clientX, touch.clientY, touch.force || 0);
   };
 
-  private handleSwipeEnd = (event: TouchEvent) => {
-    this.clearTimers();
-
+  private finalizeSingleContactEnd(clientX: number, clientY: number, pressure: number) {
     if (!this.isMultiTouch && this.touchCount === 1) {
-      const touch = event.changedTouches[0];
       const endTime = Date.now();
       const duration = endTime - this.startTime;
       const startCoords: ICoords = { x: this.startX, y: this.startY };
-      const endCoords: ICoords = { x: touch.clientX, y: touch.clientY };
+      const endCoords: ICoords = { x: clientX, y: clientY };
 
       // Check for tap/press/hold (low movement)
-      const isTapValid = isTapMovementValid(
-        this.startX,
-        this.startY,
-        touch.clientX,
-        touch.clientY
-      );
+      const isTapValid = isTapMovementValid(this.startX, this.startY, clientX, clientY);
 
       if (isTapValid && !this.holdFired) {
         // Classify the tap gesture
@@ -310,11 +350,11 @@ export default class Tocada {
           // Also check position proximity for double tap
           const tapPositionValid =
             this.lastTapTime === 0 ||
-            isTapMovementValid(this.lastTapX, this.lastTapY, touch.clientX, touch.clientY, 30);
+            isTapMovementValid(this.lastTapX, this.lastTapY, clientX, clientY, 30);
 
           const tapDetails: ITapEventDetails = {
             duration,
-            pressure: touch.force || 0,
+            pressure,
             element: this.startingElement,
             coords: endCoords,
             startTime: this.startTime,
@@ -328,13 +368,13 @@ export default class Tocada {
             this.lastTapTime = 0; // Reset to prevent triple-tap triggering double
           } else {
             this.lastTapTime = endTime;
-            this.lastTapX = touch.clientX;
-            this.lastTapY = touch.clientY;
+            this.lastTapX = clientX;
+            this.lastTapY = clientY;
           }
         } else if (tapType === "press") {
           this.dispatchTapEvent("press", {
             duration,
-            pressure: touch.force || 0,
+            pressure,
             element: this.startingElement,
             coords: endCoords,
             startTime: this.startTime,
@@ -391,11 +431,8 @@ export default class Tocada {
       );
 
       if (swipeAnalysis.isSwipe && swipeAnalysis.direction) {
-        this.endPressure = touch.force || 0;
-        const endingElement = document.elementFromPoint(
-          touch.clientX,
-          touch.clientY
-        ) as HTMLElement;
+        this.endPressure = pressure;
+        const endingElement = document.elementFromPoint(clientX, clientY) as HTMLElement;
 
         const detail = buildSwipeEventDetails(
           startCoords,
@@ -427,9 +464,15 @@ export default class Tocada {
         this.reset();
       }
     }
+  }
+
+  private handleSwipeEnd = (event: TouchEvent) => {
+    this.clearTimers();
+    const touch = event.changedTouches[0];
+    this.finalizeSingleContactEnd(touch.clientX, touch.clientY, touch.force || 0);
   };
 
-  private handleGestureStart = (_event: TouchEvent) => {
+  private handleGestureStart = (_event?: TouchEvent) => {
     this.isMultiTouch = true;
   };
 
@@ -451,87 +494,28 @@ export default class Tocada {
     }
   };
 
-  private handleGestureEnd = (event: TouchEvent) => {
-    // Get end positions for all touches
-    // Combine event.touches (still active) and event.changedTouches (just ended)
-    const endPositions: ICoords[] = [];
-    
-    // Add touches that are still active
-    for (let i = 0; i < event.touches.length; i++) {
-      endPositions.push({
-        x: event.touches[i].clientX,
-        y: event.touches[i].clientY,
-      });
-    }
-    
-    // Add touches that just ended
-    for (let i = 0; i < event.changedTouches.length; i++) {
-      endPositions.push({
-        x: event.changedTouches[i].clientX,
-        y: event.changedTouches[i].clientY,
-      });
-    }
-
-    // TODO: Implement better palm swipe detection
-    // Handle palm swipe
-    // if (this.isPalmSwipe && this.palmStartPositions.length >= this.thresholds.palmMinTouches) {
-    //   const direction = getPalmSwipeDirection(this.palmStartPositions, endPositions);
-    //   const duration = Date.now() - this.startTime;
-    //   const metrics = getPalmSwipeMetrics(this.palmStartPositions, endPositions, duration);
-
-    //   if (direction && metrics.distance > this.thresholds.swipeThreshold) {
-    //     const palmDetails: IPalmSwipeEventDetails = {
-    //       direction,
-    //       touchCount: this.palmStartPositions.length,
-    //       distance: metrics.distance,
-    //       velocity: metrics.velocity,
-    //       startPositions: this.palmStartPositions,
-    //       endPositions,
-    //     };
-
-    //     // Note: High precision fields are not available for palm swipes (multi-touch)
-    //     // as touchPath is only tracked for single-touch gestures
-
-    //     // Fire generic palm swipe first
-    //     this.dispatchPalmSwipeEvent("swipepalm", palmDetails);
-
-    //     // Then fire directional variant
-    //     const directionEvent = `swipepalm${direction}` as TGestureType;
-    //     this.dispatchPalmSwipeEvent(directionEvent, palmDetails);
-    //   }
-
-    //   this.reset();
-    //   return;
-    // }
-
-    // Fire generic "gesture" event first (before any specific gesture detection)
-    // This is like keydown - a generic hook for developers
+  private finalizeMultiContactGesture(endPositions: ICoords[]) {
     this.dispatchGestureEvent("gesture", {
       touchCount: this.touchCount,
     });
 
-    // Handle two-finger gestures (rotation and pinch/spread)
-    // Use latest tracked positions if available, otherwise use endPositions
     let endTouch1: ICoords | null = null;
     let endTouch2: ICoords | null = null;
-    
+
     if (this.latestTouch1 && this.latestTouch2) {
-      // Use the latest tracked positions from move events
       endTouch1 = this.latestTouch1;
       endTouch2 = this.latestTouch2;
     } else if (endPositions.length >= 2) {
-      // Fall back to end positions if we don't have latest positions
       endTouch1 = endPositions[0];
       endTouch2 = endPositions[1];
     }
-    
+
     if (
       this.gestureStartTouch1 &&
       this.gestureStartTouch2 &&
       endTouch1 &&
       endTouch2
     ) {
-      // Detect rotation first - prioritize rotation over pinch/spread
       const rotationResult = detectRotation(
         this.gestureStartTouch1,
         this.gestureStartTouch2,
@@ -540,7 +524,6 @@ export default class Tocada {
         this.thresholds.rotateMinAngle
       );
 
-      // If rotation is significant, fire rotation events and skip pinch/spread
       if (rotationResult.direction) {
         const rotateDetails: IRotateEventDetails = {
           angle: rotationResult.angle,
@@ -550,23 +533,18 @@ export default class Tocada {
           centerPoint: rotationResult.centerPoint,
         };
 
-        // Fire generic rotate first
         this.dispatchRotateEvent("rotate", rotateDetails);
 
-        // Then fire directional variant
         if (rotationResult.direction === "clockwise") {
           this.dispatchRotateEvent("rotateclockwise", rotateDetails);
         } else {
           this.dispatchRotateEvent("rotatecounterclockwise", rotateDetails);
         }
 
-        // Rotation takes priority - skip pinch/spread detection
         this.reset();
         return;
       }
 
-      // Only check for pinch/spread if rotation was NOT significant
-      // Build pinch/spread event details
       const pinchSpreadDetails = buildPinchSpreadEventDetails(
         this.gestureStartTouch1,
         this.gestureStartTouch2,
@@ -574,14 +552,11 @@ export default class Tocada {
         endTouch2
       );
 
-      // Calculate distance change
       const distanceChange = Math.abs(
         this.latestGestureDistance - this.gestureStartDistance
       );
 
-      // Only fire pinch/spread if distance change meets minimum threshold
       if (distanceChange >= this.thresholds.pinchSpreadMinDistance) {
-        // Handle pinch/spread using the detector
         const pinchSpreadGesture = classifyPinchSpread(
           this.gestureStartDistance,
           this.latestGestureDistance
@@ -596,6 +571,165 @@ export default class Tocada {
     }
 
     this.reset();
+  }
+
+  private handleGestureEnd = (event: TouchEvent) => {
+    const endPositions: ICoords[] = [];
+
+    for (let i = 0; i < event.touches.length; i++) {
+      endPositions.push({
+        x: event.touches[i].clientX,
+        y: event.touches[i].clientY,
+      });
+    }
+
+    for (let i = 0; i < event.changedTouches.length; i++) {
+      endPositions.push({
+        x: event.changedTouches[i].clientX,
+        y: event.changedTouches[i].clientY,
+      });
+    }
+
+    // TODO: palm swipe — endPositions retained for future palm detector wiring
+
+    this.finalizeMultiContactGesture(endPositions);
+  };
+
+  private getOrderedActivePointerCoordsPair(): [ICoords, ICoords] | null {
+    if (this.pointerById.size < 2) return null;
+    const ids = [...this.pointerById.keys()].sort((a, b) => a - b);
+    const p0 = this.pointerById.get(ids[0])!;
+    const p1 = this.pointerById.get(ids[1])!;
+    return [
+      { x: p0.x, y: p0.y },
+      { x: p1.x, y: p1.y },
+    ];
+  }
+
+  private syncPointerTwoFingerGeometryFromMap() {
+    const pair = this.getOrderedActivePointerCoordsPair();
+    if (!pair) return;
+    this.latestGestureDistance = getDistanceBetweenCoords(pair[0], pair[1]);
+    this.latestTouch1 = pair[0];
+    this.latestTouch2 = pair[1];
+  }
+
+  private tryPointerCapture(e: PointerEvent) {
+    try {
+      this.element?.setPointerCapture(e.pointerId);
+    } catch {
+      /* noop */
+    }
+  }
+
+  private releasePointerCaptureSafe(id: number) {
+    try {
+      this.element?.releasePointerCapture(id);
+    } catch {
+      /* noop */
+    }
+  }
+
+  private handlePointerDown = (e: PointerEvent) => {
+    if (!this.element) return;
+    if (e.pointerType === "mouse" && e.button !== 0) return;
+    const target = e.target;
+    if (!(target instanceof Node) || !this.element.contains(target)) return;
+
+    const pressure = readPointerPressure(e);
+    this.pointerById.set(e.pointerId, { x: e.clientX, y: e.clientY, pressure });
+    this.tryPointerCapture(e);
+
+    this.activeTouches = this.pointerById.size;
+    this.touchCount = this.pointerById.size;
+
+    if (this.activeTouches > 1) {
+      this.isMultiTouch = true;
+      this.clearTimers();
+
+      if (this.pointerById.size === 2) {
+        const pair = this.getOrderedActivePointerCoordsPair();
+        if (pair) {
+          this.gestureStartDistance = getDistanceBetweenCoords(pair[0], pair[1]);
+          this.gestureStartTouch1 = { ...pair[0] };
+          this.gestureStartTouch2 = { ...pair[1] };
+          this.latestTouch1 = { ...pair[0] };
+          this.latestTouch2 = { ...pair[1] };
+          this.latestGestureDistance = this.gestureStartDistance;
+        }
+      }
+      this.handleGestureStart();
+    } else {
+      this.isMultiTouch = false;
+      this.beginSingleContactSession(e.clientX, e.clientY, pressure);
+    }
+  };
+
+  private handlePointerMove = (e: PointerEvent) => {
+    if (!this.pointerById.has(e.pointerId)) return;
+    if (e.pointerType === "mouse" && e.buttons === 0) return;
+
+    e.preventDefault();
+
+    if (this.pointerById.size >= 2) {
+      const slices = coalescedPointerSlices(e);
+      for (const pe of slices) {
+        if (!this.pointerById.has(pe.pointerId)) continue;
+        this.pointerById.set(pe.pointerId, {
+          x: pe.clientX,
+          y: pe.clientY,
+          pressure: readPointerPressure(pe),
+        });
+      }
+      this.syncPointerTwoFingerGeometryFromMap();
+      return;
+    }
+
+    const slices = coalescedPointerSlices(e);
+    for (const pe of slices) {
+      if (pe.pointerId !== e.pointerId) continue;
+      this.pointerById.set(pe.pointerId, {
+        x: pe.clientX,
+        y: pe.clientY,
+        pressure: readPointerPressure(pe),
+      });
+      this.sampleSingleContactAlongPath(pe.clientX, pe.clientY);
+    }
+  };
+
+  private handlePointerUpOrCancel = (e: PointerEvent) => {
+    if (!this.pointerById.has(e.pointerId)) return;
+
+    this.pointerById.set(e.pointerId, {
+      x: e.clientX,
+      y: e.clientY,
+      pressure: readPointerPressure(e),
+    });
+
+    const contactsBeforeEnd = this.pointerById.size;
+
+    if (contactsBeforeEnd >= 2) {
+      this.syncPointerTwoFingerGeometryFromMap();
+      this.finalizeMultiContactGesture([]);
+      this.pointerById.delete(e.pointerId);
+      this.touchCount = 0;
+    } else if (contactsBeforeEnd === 1) {
+      this.clearTimers();
+      this.finalizeSingleContactEnd(e.clientX, e.clientY, readPointerPressure(e));
+      this.pointerById.delete(e.pointerId);
+      this.touchCount = 0;
+    }
+
+    this.activeTouches = this.pointerById.size;
+    this.releasePointerCaptureSafe(e.pointerId);
+  };
+
+  private handlePointerUp = (e: PointerEvent) => {
+    this.handlePointerUpOrCancel(e);
+  };
+
+  private handlePointerCancel = (e: PointerEvent) => {
+    this.handlePointerUpOrCancel(e);
   };
 
   /**
@@ -775,6 +909,14 @@ export function useTouchEvents(
   options: ITocadaOptions = {}
 ) {
   return new Tocada(queryStringOrElement, options);
+}
+
+/** Same as {@link useTouchEvents} with `{ pointerEvents: true }` for Pointer Event input. */
+export function usePointerEvents(
+  queryStringOrElement: string | HTMLElement,
+  options: Omit<ITocadaOptions, "pointerEvents"> = {}
+) {
+  return new Tocada(queryStringOrElement, { ...options, pointerEvents: true });
 }
 
 // Re-export types for consumers

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,13 @@ export interface ITocadaOptions {
   thresholds?: IThresholds;
   eventPrefix?: string;
   useHighPrecision?: boolean;
+  /**
+   * When true, listens with Pointer Events (pointerdown / pointermove / pointerup / pointercancel)
+   * instead of touch events. Use this for mouse, pen, and touch via the unified pointer model.
+   * Do not enable together with a separate touch-only instance on the same element (double events).
+   * Move listeners use `{ passive: false }` so preventDefault can block native scrolling while tracking.
+   */
+  pointerEvents?: boolean;
 }
 
 export interface ICoords {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,10 +57,10 @@ export interface ITocadaOptions {
   eventPrefix?: string;
   useHighPrecision?: boolean;
   /**
-   * When true, listens with Pointer Events (pointerdown / pointermove / pointerup / pointercancel)
-   * instead of touch events. Use this for mouse, pen, and touch via the unified pointer model.
-   * Do not enable together with a separate touch-only instance on the same element (double events).
-   * Move listeners use `{ passive: false }` so preventDefault can block native scrolling while tracking.
+   * When true (default), listens with Pointer Events (pointerdown / pointermove / pointerup / pointercancel)
+   * for mouse, pen, and touch via the unified pointer model. Set to `false` for legacy TouchEvent-only input.
+   * Do not attach both pipelines to the same element (double events).
+   * Pointer move listeners use `{ passive: false }` so preventDefault can block native scrolling while tracking.
    */
   pointerEvents?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import type { ICoords } from "./types";
+
 export function difference(num1: number, num2: number): number {
   if (num1 < num2) {
     return num2 - num1;
@@ -6,8 +8,13 @@ export function difference(num1: number, num2: number): number {
   }
 }
 
+export function getDistanceBetweenCoords(a: ICoords, b: ICoords): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
 export function getDistanceBetweenTouchPoints(touch0: Touch, touch1: Touch): number {
-  const distanceX = touch0.clientX - touch1.clientX;
-  const distanceY = touch0.clientY - touch1.clientY;
-  return Math.hypot(distanceX, distanceY);
+  return getDistanceBetweenCoords(
+    { x: touch0.clientX, y: touch0.clientY },
+    { x: touch1.clientX, y: touch1.clientY }
+  );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

…(prior). **Docs/tests/examples pass:** README, CONTRIBUTING, `index.html`, gh-pages demo, and `index.test.ts` now consistently describe **pointer-first defaults**, **`usePointerEvents` / `useTouchEvents`**, and **`pointerEvents: false`** for TouchEvent-only tests.

### Tests

- New **`Input pipeline selection`** tests assert **which native listeners** are registered for default `Tocada`, `useTouchEvents`, and `{ pointerEvents: false }`.
- **`usePointerEvents`** has its own small describe block.
- Touch-mocked suites remain under **`Gesture Event Priority (TouchEvent pipeline)`** with explicit **`pointerEvents: false`**.
- Pointer gesture tests live under **`Pointer pipeline (default Tocada)`**.

### Examples

- **Root `index.html`**: `usePointerEvents(touchArea)` + updated copy.
- **gh-pages**: titles/placeholders, `gestureHandler` naming, “Contacts” for `touchCount` in the UI formatter, comments.

### Docs

- README **defaults** blurb, **single/multi-contact** table headers, high-precision / native API wording, **`import Tocada, { … }`** TypeScript snippet.
- CONTRIBUTING orchestration bullets mention both pipelines.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64dc13ff-6ca2-438d-a242-512cc6e955d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64dc13ff-6ca2-438d-a242-512cc6e955d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

